### PR TITLE
Added default options OLWIDGET_DEFAULTS

### DIFF
--- a/django-olwidget/olwidget/forms.py
+++ b/django-olwidget/olwidget/forms.py
@@ -122,7 +122,7 @@ def apply_maps_to_modelform_fields(fields, maps, default_options=None, default_t
     elif isinstance(maps, dict):
         maps = [[tuple(map_field_names), maps]]
 
-    default_options = default_options or {}
+    default_options = utils.get_options(default_options)
     initial_data_keymap = {}
 
     for map_definition in maps:

--- a/django-olwidget/olwidget/utils.py
+++ b/django-olwidget/olwidget/utils.py
@@ -1,9 +1,16 @@
 import re
+import settings
 
 from django.contrib.gis.gdal import OGRException, OGRGeometry
 from django.contrib.gis.geos import GEOSGeometry
 
 DEFAULT_PROJ = "4326"
+DEFAULT_OPTIONS = getattr(settings, 'OLWIDGET_DEFAULTS', {})
+
+def get_options(o):
+    options = DEFAULT_OPTIONS.copy()
+    options.update(o or {})
+    return options
 
 def url_join(*args):
     return reduce(_reduce_url_parts, args)

--- a/django-olwidget/olwidget/widgets.py
+++ b/django-olwidget/olwidget/widgets.py
@@ -54,7 +54,7 @@ class Map(forms.Widget):
         for layer in vector_layers:
             self.vector_layers.append(layer)
         self.layer_names = layer_names
-        self.options = options or {}
+        self.options = utils.get_options(options)
         # Though this layer is the olwidget.js default, it must be explicitly
         # set so {{ form.media }} knows to include osm.
         self.options['layers'] = self.options.get('layers', ['osm.mapnik'])
@@ -302,7 +302,7 @@ class MapDisplay(EditableMap):
     Convenience Map widget for a single non-editable layer, with no popups.
     """
     def __init__(self, fields=None, options=None, **kwargs):
-        options = options or {}
+        options = utils.get_options(options)
         options['editable'] = False
         super(MapDisplay, self).__init__(options, **kwargs)
         if fields:

--- a/django-olwidget/test_project/settings.py
+++ b/django-olwidget/test_project/settings.py
@@ -92,3 +92,6 @@ GOOGLE_API_KEY = "ABQIAAAARaukg-vCnyMKCmf7W1mdOhQCULP4XOMyhPd8d_NrQQEO8sT8XBTLlW
 #GOOGLE_API_KEY = "ABQIAAAARaukg-vCnyMKCmf7W1mdOhTUM1TfCWCpQbByeYgbUi08Ugq4ShQ2qaNvdgbJz36kf2mKYgbUTR6R7A" # 18.85.23.189:8000
 YAHOO_APP_ID = "JNrvOMXV34Ft.LUs2zzCI9yVPrIX1KDJ1tiNHFam9mLWl64qgtbSjenTP.ua1UWbPCbp0w6r.A--" # olwidget documentation
 
+OLWIDGET_DEFAULTS = {
+    'layers': ['google.streets']
+}


### PR DESCRIPTION
- Optional default settings OLWIDGET_DEFAULTS are read from settings.py
- get_options in utils.py takes options parameter, merges with default settings and returns merge
- widgets.py and forms.py use utils.get_options
