### PR TITLE
I have seen that this line has been commented out from some previous rele

### DIFF
--- a/js/olwidget.js
+++ b/js/olwidget.js
@@ -313,7 +313,7 @@ olwidget.Map = OpenLayers.Class(OpenLayers.Map, {
             }
             if (!extent.equals(new OpenLayers.Bounds())) {
                 this.zoomToExtent(extent);
-                //this.zoomTo(Math.min(this.getZoom(), this.opts.defaultZoom));
+                this.zoomTo(Math.min(this.getZoom(), this.opts.defaultZoom));
                 return;
             }
         }


### PR DESCRIPTION
I have seen that this line has been commented out from some previous releases. In the case zoomToDataExtent is true, it makes sense to zoom to the extent of the data for polylines and polygons.
But for point features the zoom is too high (at least for my use case), so I would leave the possibility to set the defaultZoom properties also when a zoomToDataExtent is true.
