### PR TITLE
Add a hook that Map widget subclasses can use to provide more data to the

### DIFF
--- a/django-olwidget/olwidget/widgets.py
+++ b/django-olwidget/olwidget/widgets.py
@@ -98,7 +98,20 @@ class Map(forms.Widget):
             'map_opts': simplejson.dumps(utils.translate_options(self.options)),
             'STATIC_URL': settings.STATIC_URL,
         }
+        context.update(self.get_extra_context())
         return render_to_string(self.template, context)
+
+    def get_extra_context(self):
+        """Hook that subclasses can override to add extra data for use
+        by the javascript in self.template. This is invoked by
+        self.render().
+
+        Return value should be a dictionary where keys are strings and
+        values are valid javascript, eg. JSON-encoded data.  You'll
+        also want to override the template to make use of the provided
+        data.
+        """
+        return {}
 
     def value_from_datadict(self, data, files, name):
         """ Return an array of all layers' values. """


### PR DESCRIPTION
Add a hook that Map widget subclasses can use to provide more data to the javascript... useful for eg. adding custom base layers

For example, I have mine return this dict; notice the value is a JSON string:
    {'extra_base_layers': '[{"url": "http://maps.opengeo.org/geowebcache/service/wms", "options":  {"wrapDateLine": true}, "params": {"layers": "openstreetmap", "bgcolor": "#A1BDC4", "format": "image/png"},  "class": "WMS", "name": "OpenStreetMap (OpenGeo)"}]'}

And then my template looks like this: 
https://gist.github.com/1002867

This is a more general-purpose feature that could make #60 and #47 unnecessary.
