### PR TITLE
Setuptools fixes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -128,4 +128,5 @@ setup(name='django-olwidget',
         'Programming Language :: JavaScript',
         'Topic :: Software Development :: Libraries :: Application Frameworks',
     ],
+    zip_safe=False,
 )


### PR DESCRIPTION
Fixes to allow olwidget to be installed via a setuptools dependency link.
