### PR TITLE
Storing the object olwidget.InfoMap into a variable

### DIFF
--- a/django-olwidget/olwidget/templates/olwidget/editable_layer.html
+++ b/django-olwidget/olwidget/templates/olwidget/editable_layer.html
@@ -1,1 +1,1 @@
-var olwidget_{{ id }} = new olwidget.EditableLayer("{{ id }}", {{ options|safe }})
+new olwidget.EditableLayer("{{ id }}", {{ options|safe }})


### PR DESCRIPTION
In same use cases, like to bind a field in a model admin in order to search the coordinates for a place name and pan the map to it, is often usefull get access to the object olwidget.InfoMap created.
