### PR TITLE
__init__() takes exactly 13 arguments (12 given) on django1.4

### DIFF
--- a/django-olwidget/olwidget/admin.py
+++ b/django-olwidget/olwidget/admin.py
@@ -144,8 +144,10 @@ class GeoModelAdmin(ModelAdmin):
 
         ChangeList = self.get_changelist(request)
         try:
+            self.admin_site.root_path = ""
             cl = ChangeList(request, self.model, list_display, self.list_display_links, self.list_filter,
-                self.date_hierarchy, self.search_fields, self.list_select_related, self.list_per_page, self.list_editable, self)
+                self.date_hierarchy, self.search_fields, self.list_select_related, self.list_per_page, self.list_editable,
+                self.admin_site, self)
         except IncorrectLookupParameters:
             # Wacky lookup parameters were given, so redirect to the main
             # changelist page, without parameters, and pass an 'invalid=1'


### PR DESCRIPTION
I don't know admin internals so please review this quick ugly fix before accept it.

(It will probably crash in django 1.3)
