### PR TITLE
Remove deprecated import to copycompat

### DIFF
--- a/django-olwidget/olwidget/widgets.py
+++ b/django-olwidget/olwidget/widgets.py
@@ -1,6 +1,6 @@
 import warnings
 
-import django.utils.copycompat as copy
+import copy
 from django.template.loader import render_to_string
 from django.utils import simplejson
 from django.conf import settings


### PR DESCRIPTION
Just a very quick update to remove DeprecationWarnings in Django 1.5+
