### PR TITLE
try removing data_files -- they're getting installed incorrectly!

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,30 +22,6 @@ setup(name='django-olwidget',
     url='http://olwidget.org',
     packages=['olwidget'],
     package_dir={'': 'django-olwidget'},
-    data_files=[
-        ('olwidget/templates/olwidget', [
-            'django-olwidget/olwidget/templates/olwidget/admin_olwidget.html',
-            'django-olwidget/olwidget/templates/olwidget/editable_layer.html',
-            'django-olwidget/olwidget/templates/olwidget/multi_layer_map.html',
-            'django-olwidget/olwidget/templates/olwidget/info_layer.html',
-            'django-olwidget/olwidget/templates/olwidget/test_map_template.html',
-        ]),
-        ('olwidget/static/olwidget/css', [
-            'css/olwidget.css'
-        ]),
-        ('olwidget/static/olwidget/js', [
-            'js/olwidget.js',
-            'js/cloudmade.js',
-        ]),
-        ('olwidget/static/olwidget/img', [
-            'img/extra_edit_icons.png',
-            'img/jquery_ui_license.txt',
-            'img/popup_icons.png',
-        ]),
-        ('olwidget/templates/admin', [
-            'django-olwidget/olwidget/templates/admin/olwidget_change_list.html'
-        ]),
-    ],
     classifiers=[
         'Development Status :: 4 - Beta',
         'Environment :: Web Environment',


### PR DESCRIPTION
`$ pip install django-olwidget==0.61.0`

on a docker container (i.e. not within a virtualenv) resulted in the following distribution of files:

```
  /usr/local/lib/python2.7/site-packages/olwidget/__init__.py
  /usr/local/lib/python2.7/site-packages/olwidget/admin.py
  /usr/local/lib/python2.7/site-packages/olwidget/fields.py
  /usr/local/lib/python2.7/site-packages/olwidget/forms.py
  /usr/local/lib/python2.7/site-packages/olwidget/models.py
  /usr/local/lib/python2.7/site-packages/olwidget/tests.py
  /usr/local/lib/python2.7/site-packages/olwidget/utils.py
  /usr/local/lib/python2.7/site-packages/olwidget/widgets.py
  /usr/local/olwidget/static/olwidget/css/olwidget.css
  /usr/local/olwidget/static/olwidget/img/extra_edit_icons.png
  /usr/local/olwidget/static/olwidget/img/jquery_ui_license.txt
  /usr/local/olwidget/static/olwidget/img/popup_icons.png
  /usr/local/olwidget/static/olwidget/js/cloudmade.js
  /usr/local/olwidget/static/olwidget/js/olwidget.js
  /usr/local/olwidget/templates/admin/olwidget_change_list.html
  /usr/local/olwidget/templates/olwidget/admin_olwidget.html
  /usr/local/olwidget/templates/olwidget/editable_layer.html
  /usr/local/olwidget/templates/olwidget/info_layer.html
  /usr/local/olwidget/templates/olwidget/multi_layer_map.html
  /usr/local/olwidget/templates/olwidget/test_map_template.html
```

Thus Django was unable to find the templates or static files.

The `data_files` attribute in `setup.py` does not appear to be designed for the likes of django templates/static files. Simply removing it has resolved the problem for me. However I'm not an expert on `setup.py` so I may be missing some nuance as to why `data_files` was being used...
